### PR TITLE
Feat: Add SQLite export and balance filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Tron DB Reader
 
-This script reads a Tron RocksDB database and prints the addresses and balances of all accounts.
+This script reads a Tron RocksDB database and exports the addresses and TRX balances of all accounts to a SQLite database.
 
 ## Getting Started
 
-These instructions will get you a copy of the project up and running on your local machine for development and testing purposes.
+These instructions will get you a copy of the project up and running on your local machine.
 
 ### Prerequisites
 
@@ -32,19 +32,21 @@ To use the script, run it from the command line and provide the path to your Tro
 python read_tron_db.py /path/to/your/tron/output-directory
 ```
 
+You can also specify the output SQLite database file and a minimum TRX balance to export.
+
+### Options
+
+*   `--db-file`: Path to the output SQLite database file. Defaults to `tron_balances.db`.
+*   `--min-balance`: The minimum TRX balance to export. Accounts with a balance lower than this will be skipped. Defaults to 0.
+
 ### Example
 
 ```bash
+# Export all accounts to the default tron_balances.db
 python read_tron_db.py /data/tron/output-directory
-```
 
-**Example Output:**
-
-```
-Address,Balance
-T...some_address...,1234.5678
-T...another_address...,9876.5432
-...
+# Export accounts with a balance of at least 100 TRX to a custom database file
+python read_tron_db.py /data/tron/output-directory --min-balance 100 --db-file my_tron_data.db
 ```
 
 ## How it works
@@ -53,4 +55,4 @@ The script uses the `rocksdict` library to read the RocksDB database. It checks 
 
 The values in the `account` column family are serialized using Google Protocol Buffers (Protobuf). The script uses the `.proto` files from the `java-tron` repository to generate Python classes that can parse this data.
 
-The script iterates through all the key-value pairs in the `account` column family, decodes the data, and prints the address and balance for each account. The addresses are converted to the standard base58 format for readability.
+The script iterates through all the key-value pairs in the `account` column family, decodes the data, and saves the address and TRX balance to a SQLite database. The addresses are converted to the standard base58 format for readability.

--- a/read_tron_db.py
+++ b/read_tron_db.py
@@ -2,23 +2,37 @@ import argparse
 import rocksdict
 from core.Tron_pb2 import Account
 import base58
+import sqlite3
+import sys
+
+def setup_database(db_file):
+    """Sets up the SQLite database and creates the accounts table."""
+    conn = sqlite3.connect(db_file)
+    c = conn.cursor()
+    c.execute('''
+        CREATE TABLE IF NOT EXISTS accounts (
+            address TEXT PRIMARY KEY,
+            trx_balance REAL
+        )
+    ''')
+    conn.commit()
+    return conn
 
 def main():
-    parser = argparse.ArgumentParser(description='Read account data from a Tron RocksDB database.')
+    parser = argparse.ArgumentParser(description='Read account data from a Tron RocksDB database and export to SQLite.')
     parser.add_argument('db_path', type=str, help='Path to the Tron RocksDB database directory.')
+    parser.add_argument('--db-file', type=str, default='tron_balances.db', help='Path to the SQLite database file.')
+    parser.add_argument('--min-balance', type=float, default=0, help='Minimum TRX balance to export.')
     args = parser.parse_args()
 
     try:
-        # Open the database in read-only mode.
-        # raw_mode=True is important because the data is not encoded by rocksdict.
         db = rocksdict.Rdict(args.db_path, options=rocksdict.Options(raw_mode=True))
     except Exception as e:
-        print(f"Error opening database: {e}")
+        print(f"Error opening RocksDB database: {e}")
         return
 
     try:
         cf_names = rocksdict.Rdict.list_cf(args.db_path)
-
         account_cf_name = None
         if 'account' in cf_names:
             account_cf_name = 'account'
@@ -29,41 +43,47 @@ def main():
             print(f"Available column families: {cf_names}")
             db.close()
             return
-
         account_cf = db.get_column_family(account_cf_name)
         print(f"Using column family: '{account_cf_name}'")
-
     except Exception as e:
         print(f"Error accessing column family: {e}")
         db.close()
         return
 
-    print("Address,Balance")
+    conn = setup_database(args.db_file)
+    c = conn.cursor()
+
+    count = 0
+    exported_count = 0
     # Iterate over the key-value pairs in the account column family.
     for key, value in account_cf.items():
+        count += 1
+        if count % 100000 == 0:
+            sys.stdout.write(f"\rProcessed {count} accounts...")
+            sys.stdout.flush()
+
         try:
-            # The key is the account address in bytes.
-            # The value is a serialized Account protobuf message.
             account = Account()
             account.ParseFromString(value)
 
-            # The key from the database is the full 21-byte address.
-            # We can directly encode it using base58check.
-            address_b58 = base58.b58encode_check(key).decode('utf-8')
-
-            # The balance is in SUN (1 TRX = 1,000,000 SUN).
             balance_sun = account.balance
             balance_trx = balance_sun / 1_000_000
 
-            print(f"{address_b58},{balance_trx}")
+            if balance_trx >= args.min_balance:
+                address_b58 = base58.b58encode_check(key).decode('utf-8')
 
-        except Exception as e:
-            # It's possible some entries are not valid accounts, so we'll just skip them.
-            # print(f"Could not parse account with key {key.hex()}: {e}")
+                c.execute("INSERT OR REPLACE INTO accounts (address, trx_balance) VALUES (?, ?)",
+                          (address_b58, balance_trx))
+                exported_count += 1
+
+        except Exception:
             pass
 
-    # Clean up and close the database.
+    conn.commit()
+    conn.close()
     db.close()
+
+    print(f"\nDone. Processed {count} accounts and exported {exported_count} to '{args.db_file}'.")
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This commit enhances the Tron DB reader script with two new features based on user feedback:
- The script now exports the account addresses and TRX balances to a SQLite database file.
- A command-line option `--min-balance` has been added to allow filtering of accounts by a minimum TRX balance.

The script has been updated to use the `sqlite3` module, and the `README.md` has been updated to document the new features and usage.